### PR TITLE
Update payplug.php

### DIFF
--- a/payplug.php
+++ b/payplug.php
@@ -165,7 +165,7 @@ class Payplug extends PaymentModule
 				$process = curl_init(Payplug::URL_AUTOCONFIG);
 				curl_setopt($process, CURLOPT_USERPWD, Tools::getValue('email').':'.Tools::getValue('password'));
 				curl_setopt($process, CURLOPT_RETURNTRANSFER, true);
-				curl_setopt($process, CURLOPT_SSLVERSION, defined(CURL_SSLVERSION_TLSv1) ? CURL_SSLVERSION_TLSv1 : 1);
+				curl_setopt($process, CURLOPT_SSLVERSION, defined('CURL_SSLVERSION_TLSv1') ? CURL_SSLVERSION_TLSv1 : 1);
 				curl_setopt($process, CURLOPT_SSL_VERIFYPEER, true);
 				curl_setopt($process, CURLOPT_SSL_VERIFYHOST, true);
 				curl_setopt($process, CURLOPT_CAINFO, realpath(dirname(__FILE__).'/cacert.pem')); //work only wiht cURL 7.10+


### PR DESCRIPTION
fix warning "Use of undefined constant CURL_SSLVERSION_TLSv1 - assumed 'CURL_SSLVERSION_TLSv1''
